### PR TITLE
Fixing firstboot wifi connection issue

### DIFF
--- a/wifisetup/wifiConnect.py
+++ b/wifisetup/wifiConnect.py
@@ -45,6 +45,10 @@ with open("/etc/wpa_supplicant/wpa_supplicant.conf", "a") as wifiFile:
 
 os.system("wpa_cli reconfigure")
 time.sleep(5)
+os.system("systemctl daemon-reload")
+time.sleep(5)
+os.system("systemctl restart dhcpcd")
+time.sleep(5)
 
 # It's likely that the block following this one will be one that uses the
 # internet - such as a download file or apt-get block. It takes a few seconds


### PR DESCRIPTION
Device: Pi Zero W
Issue: Wifi setup fails to connect to network/internet during first boot. Internet/network works after reboot.

Workaround: add call to restart systemctl daemon and dhcpcd to establish connectivity without rebooting.